### PR TITLE
Synchronization

### DIFF
--- a/src/main/java/name/dmaus/schxslt/Schematron.java
+++ b/src/main/java/name/dmaus/schxslt/Schematron.java
@@ -72,7 +72,7 @@ public final class Schematron
 
     private final Document styleSheet;
 
-    private Map<String, Object> options = new HashMap<String, Object>();
+    private final Map<String, Object> options = new HashMap<String, Object>();
 
     @GuardedBy("this")
     private TransformerFactory transformerFactory;

--- a/src/main/java/name/dmaus/schxslt/Schematron.java
+++ b/src/main/java/name/dmaus/schxslt/Schematron.java
@@ -275,7 +275,7 @@ public final class Schematron
         this.transformerFactory = transformerFactory;
     }
 
-    private synchronized Document loadSchematron (final Source source)
+    private Document loadSchematron (final Source source)
     {
         String systemId = source.getSystemId();
 

--- a/src/main/java/name/dmaus/schxslt/Schematron.java
+++ b/src/main/java/name/dmaus/schxslt/Schematron.java
@@ -238,10 +238,8 @@ public final class Schematron
      */
     public Result validate (final Source document, final Map<String, Object> parameters) throws SchematronException
     {
-        synchronized (validator) {
-            if (validator == null) {
-                validator = createValidator();
-            }
+        if (validator == null) {
+            validator = createValidator();
         }
         return validator.validate(document, parameters);
     }

--- a/src/main/java/name/dmaus/schxslt/Schematron.java
+++ b/src/main/java/name/dmaus/schxslt/Schematron.java
@@ -77,9 +77,6 @@ public final class Schematron
     @GuardedBy("this")
     private List<String> pipelineSteps;
 
-    @GuardedBy("this")
-    private Templates validatesTemplates;
-
     @GuardedBy("validator")
     private SchematronValidator validator;
 
@@ -238,10 +235,7 @@ public final class Schematron
      */
     public Result validate (final Source document, final Map<String, Object> parameters) throws SchematronException
     {
-        if (validator == null) {
-            validator = createValidator();
-        }
-        return validator.validate(document, parameters);
+        return createValidator().validate(document, parameters);
     }
 
     /**
@@ -259,10 +253,11 @@ public final class Schematron
     public synchronized SchematronValidator createValidator () throws SchematronException
     {
         try {
-            if (validatesTemplates == null) {
-                validatesTemplates = transformerFactory.newTemplates(new DOMSource(getValidationStylesheet()));
+            if (validator == null) {
+                Templates templates = transformerFactory.newTemplates(new DOMSource(getValidationStylesheet()));
+                validator = new SchematronValidator(templates);
             }
-            return new SchematronValidator(validatesTemplates);
+            return validator;
         } catch (TransformerException e) {
             throw new SchematronException("Error compiling validation stylesheet", e);
         }

--- a/src/main/java/name/dmaus/schxslt/Schematron.java
+++ b/src/main/java/name/dmaus/schxslt/Schematron.java
@@ -77,9 +77,6 @@ public final class Schematron
     @GuardedBy("this")
     private List<String> pipelineSteps;
 
-    @GuardedBy("this")
-    private Templates validatesTemplates;
-
     @GuardedBy("validator")
     private SchematronValidator validator;
 
@@ -238,10 +235,7 @@ public final class Schematron
      */
     public Result validate (final Source document, final Map<String, Object> parameters) throws SchematronException
     {
-        if (validator == null) {
-            validator = createValidator();
-        }
-        return validator.validate(document, parameters);
+        return createValidator().validate(document, parameters);
     }
 
     /**
@@ -256,13 +250,16 @@ public final class Schematron
         return compile();
     }
 
-    public synchronized SchematronValidator createValidator () throws SchematronException
+    public SchematronValidator createValidator () throws SchematronException
     {
         try {
-            if (validatesTemplates == null) {
-                validatesTemplates = transformerFactory.newTemplates(new DOMSource(getValidationStylesheet()));
+            synchronized (transformerFactory) {
+                if (validator == null) {
+                    Templates templates = transformerFactory.newTemplates(new DOMSource(getValidationStylesheet()));
+                    validator = new SchematronValidator(templates);
+                }
             }
-            return new SchematronValidator(validatesTemplates);
+            return validator;
         } catch (TransformerException e) {
             throw new SchematronException("Error compiling validation stylesheet", e);
         }

--- a/src/main/java/name/dmaus/schxslt/Schematron.java
+++ b/src/main/java/name/dmaus/schxslt/Schematron.java
@@ -155,7 +155,7 @@ public final class Schematron
         return new Schematron(schematron, phase, transformerFactory, options);
     }
 
-    private synchronized void setPipelineSteps (final List<String> steps)
+    private void setPipelineSteps (final List<String> steps)
     {
         pipelineSteps = Collections.unmodifiableList(steps);
     }
@@ -250,12 +250,14 @@ public final class Schematron
         return compile();
     }
 
-    public synchronized SchematronValidator createValidator () throws SchematronException
+    public SchematronValidator createValidator () throws SchematronException
     {
         try {
-            if (validator == null) {
-                Templates templates = transformerFactory.newTemplates(new DOMSource(getValidationStylesheet()));
-                validator = new SchematronValidator(templates);
+            synchronized (transformerFactory) {
+                if (validator == null) {
+                    Templates templates = transformerFactory.newTemplates(new DOMSource(getValidationStylesheet()));
+                    validator = new SchematronValidator(templates);
+                }
             }
             return validator;
         } catch (TransformerException e) {
@@ -263,7 +265,7 @@ public final class Schematron
         }
     }
 
-    private synchronized void setTransformerFactory (final TransformerFactory transformerFactory)
+    private void setTransformerFactory (final TransformerFactory transformerFactory)
     {
         this.transformerFactory = transformerFactory;
     }

--- a/src/test/java/name/dmaus/schxslt/SchematronTest.java
+++ b/src/test/java/name/dmaus/schxslt/SchematronTest.java
@@ -49,42 +49,12 @@ public class SchematronTest
     }
 
     @Test
-    public void functionalConstructorWithOptions ()
-    {
-        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema10), "always-valid");
-        assertNotEquals(schematron, schematron.withOptions(new HashMap<String,Object>()));
-    }
-
-    @Test
     public void functionalConstructorWithOptionsKeepsPhase () throws Exception
     {
-        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema20WithPhase), "phase");
-        Result result = schematron.withOptions(new HashMap<String,Object>()).validate(getResourceAsStream(simpleSchema10));
+        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema20WithPhase), "phase", null, new HashMap<String,Object>());
+        Result result = schematron.validate(getResourceAsStream(simpleSchema10));
         assertTrue(result.isValid());
     }
-
-    @Test
-    public void functionalConstructorWithTransformerFactory ()
-    {
-        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema10), "always-valid");
-        assertNotEquals(schematron, schematron.withTransformerFactory(TransformerFactory.newInstance()));
-    }
-
-    @Test
-    public void functionalConstructorWithPipelineSteps ()
-    {
-        String[] steps = {"foo"};
-        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema10), "always-valid");
-        assertNotEquals(schematron, schematron.withPipelineSteps(steps));
-    }
-
-    @Test
-    public void functionalConstructorWithPhase ()
-    {
-        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema10), "always-valid");
-        assertNotEquals(schematron, schematron.withPhase("phase"));
-    }
-
 
     @Test
     public void newSchematronForXSLT10 () throws Exception


### PR DESCRIPTION
- Remove deprecated with-methods
- #compile can be called from constructor, it does not depend on state that can be set after construction. synchronization can then be removed.
- throw schematronexception from constructors and static instantiators
- remove setters for with-methods