### PR TITLE
Unit tests for XSLT 2.0

### DIFF
--- a/src/test/java/name/dmaus/schxslt/SchematronTest.java
+++ b/src/test/java/name/dmaus/schxslt/SchematronTest.java
@@ -78,12 +78,12 @@ public class SchematronTest
     @Test
     public void extParamForXSLT20 () throws Exception
     {
-        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema10), "external-param");
+        Schematron schematron = new Schematron(getResourceAsStream(simpleSchema20), "external-param");
 
         HashMap<String,Object> map = new HashMap<String,Object>();
         map.put("external-param", new Integer(1));
 
-        Result result = schematron.validate(getResourceAsStream(simpleSchema10), map);
+        Result result = schematron.validate(getResourceAsStream(simpleSchema20), map);
         assertTrue(result.isValid());
     }
 
@@ -92,7 +92,7 @@ public class SchematronTest
     public void newSchematronForXSLT20 () throws Exception
     {
         Schematron schematron = new Schematron(getResourceAsStream(simpleSchema20), "always-valid");
-        Result result = schematron.validate(getResourceAsStream(simpleSchema10));
+        Result result = schematron.validate(getResourceAsStream(simpleSchema20));
         assertTrue(result.isValid());
     }
 


### PR DESCRIPTION
Shouldn't the tests `extParamForXSLT20` and `newSchematronForXSLT20` use the file `simpleSchema20`?

Just so you know, I was browsing your code and I'm using this pull request as a mean for discussion. I might be wrong but, at first sight, this seems like a copy/paste mistake...