### PR TITLE
fix npe when using xslt3

### DIFF
--- a/src/main/java/name/dmaus/schxslt/adapter/SchXslt2.java
+++ b/src/main/java/name/dmaus/schxslt/adapter/SchXslt2.java
@@ -33,7 +33,7 @@ import name.dmaus.schxslt.SchematronException;
  */
 public final class SchXslt2 implements Adapter
 {
-    private static final List<String> STEPS = List.of("/content/transpile.xsl");
+    private static final List<String> STEPS = List.of("classpath:/content/transpile.xsl");
 
     public List<String> getTranspilerStylesheets (final String queryBinding) throws SchematronException
     {

--- a/src/test/java/name/dmaus/schxslt/SchematronTest.java
+++ b/src/test/java/name/dmaus/schxslt/SchematronTest.java
@@ -25,20 +25,20 @@
 package name.dmaus.schxslt;
 
 import name.dmaus.schxslt.adapter.SchXslt;
-
+import name.dmaus.schxslt.adapter.SchXslt2;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import javax.xml.transform.stream.StreamSource;
-
 import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SchematronTest
 {
     final String simpleSchema10 = "/simple-schema-10.sch";
     final String simpleSchema20 = "/simple-schema-20.sch";
+    final String simpleSchema30 = "/simple-schema-30.sch";
     final String simpleSchema20catalog = "/simple-schema-20-catalog.sch";
     final String simpleSchema20WithPhase = "/simple-schema-20-phase.sch";
 
@@ -95,6 +95,18 @@ public class SchematronTest
     {
         Schematron schematron = new Schematron(new SchXslt(), getResourceAsStream(simpleSchema20), "always-valid");
         Result result = schematron.validate(getResourceAsStream(simpleSchema20));
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void newSchematronForXSLT30 () throws Exception
+    {
+        Schematron schematron = new Schematron(new SchXslt2(), getResourceAsStream(simpleSchema30), "always-valid");
+
+        HashMap<String,Object> map = new HashMap<String,Object>();
+        map.put("external-param", Integer.valueOf(1));
+
+        Result result = schematron.validate(getResourceAsStream(simpleSchema30),map);
         assertTrue(result.isValid());
     }
 

--- a/src/test/resources/simple-schema-30.sch
+++ b/src/test/resources/simple-schema-30.sch
@@ -1,0 +1,20 @@
+<!-- Simple XSLT 3.0 Schematron -->
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt3">
+  <let name="external-param" value="2"/>
+  <phase id="external-param">
+    <active pattern="external-param"/>
+  </phase>
+  <phase id="always-valid">
+    <active pattern="always-valid"/>
+  </phase>
+  <pattern id="always-valid">
+    <rule context="*">
+      <assert test="true()"/>
+    </rule>
+  </pattern>
+  <pattern id="external-param">
+    <rule context="/">
+      <assert test="$external-param = 1"/>
+    </rule>
+  </pattern>
+</schema>


### PR DESCRIPTION
In SchXslt `classpath:` was missing. Also added a test.

By the way shouldn't all tests fail that do not set `external-param` to 1? Because of this rule:

```xml
    <rule context="/">
      <assert test="$external-param = 1"/>
    </rule>
```